### PR TITLE
Filter out section headers from INFO queries.

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -230,7 +230,7 @@ module Make(IO : Make.IO) = struct
     return_bulk reply >>= function
       | Some b ->
           let fields = String.nsplit b "\r\n" in
-          let fields = List.filter (fun x -> x <> "") fields in
+          let fields = List.filter (fun x -> x <> "" && not (String.starts_with x "#") ) fields in
           IO.return (List.map (fun f -> String.split f ":") fields)
       | None   -> IO.return []
 


### PR DESCRIPTION
Section headers do not follow the key:value syntax, so
splitting on these lines raises a Not_found exception.
